### PR TITLE
Add ignoreBranchProtection configuration to allow importing github project when branch protection is configured.

### DIFF
--- a/github-plugin/src/main/java/com/googlesource/gerrit/plugins/github/GitHubConfig.java
+++ b/github-plugin/src/main/java/com/googlesource/gerrit/plugins/github/GitHubConfig.java
@@ -39,6 +39,7 @@ public class GitHubConfig extends GitHubOAuthConfig {
   private static final String CONF_PULL_REQUEST_LIST_LIMIT = "pullRequestListLimit";
   private static final String CONF_REPOSITORY_LIST_PAGE_SIZE = "repositoryListPageSize";
   private static final String CONF_REPOSITORY_LIST_LIMIT = "repositoryListLimit";
+  private static final String CONF_IGNORE_BRANCH_PROTECTION = "ignoreBranchProtection";
   private static final String CONF_PUBLIC_BASE_PROJECT = "publicBaseProject";
   private static final String CONF_PRIVATE_BASE_PROJECT = "privateBaseProject";
   private static final String CONF_WEBHOOK_SECRET = "webhookSecret";
@@ -52,6 +53,7 @@ public class GitHubConfig extends GitHubOAuthConfig {
   public final int pullRequestListLimit;
   public final int repositoryListPageSize;
   public final int repositoryListLimit;
+  public final boolean ignoreBranchProtection;
   public final String privateBaseProject;
   public final String publicBaseProject;
   public final String allProjectsName;
@@ -89,6 +91,7 @@ public class GitHubConfig extends GitHubOAuthConfig {
     pullRequestListLimit = config.getInt(CONF_SECTION, CONF_PULL_REQUEST_LIST_LIMIT, 50);
     repositoryListPageSize = config.getInt(CONF_SECTION, CONF_REPOSITORY_LIST_PAGE_SIZE, 50);
     repositoryListLimit = config.getInt(CONF_SECTION, CONF_REPOSITORY_LIST_LIMIT, 50);
+    ignoreBranchProtection = config.getBoolean(CONF_SECTION, CONF_IGNORE_BRANCH_PROTECTION, false);
 
     gitDir = site.resolve(config.getString("gerrit", null, "basePath"));
     if (gitDir == null) {

--- a/github-plugin/src/main/java/com/googlesource/gerrit/plugins/github/git/ProtectedBranchesCheckStep.java
+++ b/github-plugin/src/main/java/com/googlesource/gerrit/plugins/github/git/ProtectedBranchesCheckStep.java
@@ -26,6 +26,8 @@ import org.kohsuke.github.GHBranch;
 
 public class ProtectedBranchesCheckStep extends ImportStep {
 
+  private final GitHubConfig config;
+
   public interface Factory {
     ProtectedBranchesCheckStep create(
         @Assisted("organisation") String organisation, @Assisted("name") String repository);
@@ -38,10 +40,15 @@ public class ProtectedBranchesCheckStep extends ImportStep {
       @Assisted("organisation") String organisation,
       @Assisted("name") String repository) {
     super(config.gitHubUrl, organisation, repository, gitHubRepoFactory);
+    this.config = config;
   }
 
   @Override
   public void doImport(ProgressMonitor progress) throws Exception {
+    if (this.config.ignoreBranchProtection) {
+      return;
+    }
+
     Collection<GHBranch> branches = getRepository().getBranches().values();
     progress.beginTask("Checking branch protection", branches.size());
     List<String> protectedBranchNames = Lists.newLinkedList();


### PR DESCRIPTION
With https://github.com/GerritCodeReview/plugins_github/commit/04b0e495de3442a5cf5c110664f718d7b50ce9c7, when there is a branch protection is configured on the repository, the import is not allowed.
This change makes the feature as optional by `ignoreBranchProtection` configuration in `github` section.
